### PR TITLE
Adding opencv-contrib non-free version

### DIFF
--- a/notebook/requirements.txt
+++ b/notebook/requirements.txt
@@ -20,6 +20,7 @@ scikit-learn==0.22.2
 tensorflow==2.0.0b1
 seaborn==0.10.1
 h5py==2.10.0
+opencv-python==4.2.0.34
 opencv-contrib-python-nonfree==4.1.1.1
 easydict==1.9
 Pillow==7.1.2

--- a/notebook/requirements.txt
+++ b/notebook/requirements.txt
@@ -20,7 +20,7 @@ scikit-learn==0.22.2
 tensorflow==2.0.0b1
 seaborn==0.10.1
 h5py==2.10.0
-opencv-python-nonfree==4.1.1.1
+opencv-contrib-python-nonfree==4.1.1.1
 easydict==1.9
 Pillow==7.1.2
 spacy==2.2.4

--- a/notebook/requirements.txt
+++ b/notebook/requirements.txt
@@ -20,8 +20,7 @@ scikit-learn==0.22.2
 tensorflow==2.0.0b1
 seaborn==0.10.1
 h5py==2.10.0
-opencv-python==4.2.0.34
-opencv-contrib-python==4.2.0.34
+opencv-python-nonfree==4.1.1.1
 easydict==1.9
 Pillow==7.1.2
 spacy==2.2.4


### PR DESCRIPTION
Changing to non-free version of opencv-contrib as opencv-contrib version does not support patented featuers such as surf and sift anymore.