### PR TITLE
opencv-python-contrib-nonfree has been removed from pypi, downgrade t…

### DIFF
--- a/notebook/requirements.txt
+++ b/notebook/requirements.txt
@@ -18,7 +18,7 @@ tensorflow==2.0.0b1
 seaborn==0.10.1
 h5py==2.10.0
 opencv-python==4.2.0.34
-opencv-contrib-python-nonfree==4.1.1.1
+opencv-contrib-python==3.4.2.1
 easydict==1.9
 Pillow==7.1.2
 spacy==2.2.4

--- a/restricted-notebook/requirements.txt
+++ b/restricted-notebook/requirements.txt
@@ -15,7 +15,7 @@ tensorflow==2.0.0b1
 seaborn==0.10.1
 h5py==2.10.0
 opencv-python==4.2.0.34
-opencv-contrib-python-nonfree==4.1.1.1
+opencv-contrib-python==3.4.2.1
 easydict==1.9
 Pillow==7.1.2
 spacy==2.2.4


### PR DESCRIPTION
* opencv-python-contrib-nonfree==4.1.1.1 has been removed from pypi 5 days ago https://github.com/skvark/opencv-python/issues/348

* Downgrade controb to 3.4 to include surf and shift