### PR TITLE
Add bidata notebook

### DIFF
--- a/.github/workflows/build_and_push_all_images.yml
+++ b/.github/workflows/build_and_push_all_images.yml
@@ -371,6 +371,7 @@ jobs:
     secrets: inherit
 
   bidata_notebook:
+    needs: [minimal_notebook]
     uses: ./.github/workflows/build_image.yml
     with:
       force_build: ${{ inputs.force_build }}

--- a/.github/workflows/build_and_push_all_images.yml
+++ b/.github/workflows/build_and_push_all_images.yml
@@ -375,8 +375,8 @@ jobs:
     with:
       force_build: ${{ inputs.force_build }}
       registry: ${{ inputs.registry }}
-      base_image_name: jupyter/minimal-notebook
-      base_image_tag: notebook-6.5.3
+      base_image_name: ${{ inputs.registry }}/digiklausur/docker-stacks/minimal-notebook
+      base_image_tag: ${{ inputs.tag }}    
       image_path: images/bidata-notebook
       image_name: bidata-notebook
       image_tag: ${{ inputs.tag }}

--- a/.github/workflows/build_and_push_all_images.yml
+++ b/.github/workflows/build_and_push_all_images.yml
@@ -369,3 +369,32 @@ jobs:
       e2xgrader_version: ${{ inputs.e2xgrader_version }}
       e2xgrader_branch: ${{ inputs.e2xgrader_branch }}
     secrets: inherit
+
+  bidata_notebook:
+    uses: ./.github/workflows/build_image.yml
+    with:
+      force_build: ${{ inputs.force_build }}
+      registry: ${{ inputs.registry }}
+      base_image_name: jupyter/minimal-notebook
+      base_image_tag: notebook-6.5.3
+      image_path: images/bidata-notebook
+      image_name: bidata-notebook
+      image_tag: ${{ inputs.tag }}
+      push: ${{ inputs.push }}
+    secrets: inherit
+
+  e2x_bidata_notebook:
+    needs: [bidata_notebook]
+    uses: ./.github/workflows/build_e2xgrader_images.yml
+    with:
+      force_build: ${{ inputs.force_build || needs.bidata_notebook.outputs.did_build_image == 'true' }}
+      registry: ${{ inputs.registry }}
+      image_name: bidata-notebook
+      image_tag: ${{ inputs.tag }}
+      base_image_name: ${{ inputs.registry }}/digiklausur/docker-stacks/bidata-notebook
+      base_image_tag: ${{ inputs.tag }}
+      push: ${{ inputs.push }}
+      e2xgrader_installation_source: ${{ inputs.e2xgrader_installation_source }}
+      e2xgrader_version: ${{ inputs.e2xgrader_version }}
+      e2xgrader_branch: ${{ inputs.e2xgrader_branch }}
+    secrets: inherit

--- a/images/bidata-notebook/Dockerfile
+++ b/images/bidata-notebook/Dockerfile
@@ -1,0 +1,21 @@
+ARG IMAGE_SOURCE=ghcr.io/digiklausur/docker-stacks/minimal-notebook:latest
+FROM $IMAGE_SOURCE
+
+LABEL maintainer="e2x project H-BRS <e2x@inf.h-brs.de>"
+LABEL description="e2x business data notebook"
+LABEL org.opencontainers.image.description="e2x business data notebook"
+LABEL org.opencontainers.image.authors="e2x project H-BRS <e2x@inf.h-brs.de>"
+
+
+USER $NB_USER
+
+COPY requirements.txt /tmp/requirements.txt
+
+# Create a new conda environment for bi and install the requirements there
+RUN mamba create -n bi "python=3.12" pip -y \
+    && /opt/conda/envs/bi/bin/python -m pip install --no-cache-dir -r /tmp/requirements.txt \
+    && mamba clean -afy \
+    && find /opt/conda/ -follow -type f -name '*.js.map' -delete
+
+# Go to /opt/conda/share/kernels/python3 and replace the path to the python executable with the one from the bi environment in kernel.json
+RUN sed -i 's|/opt/conda/bin/python|/opt/conda/envs/bi/bin/python|g' /opt/conda/share/jupyter/kernels/python3/kernel.json

--- a/images/bidata-notebook/requirements.txt
+++ b/images/bidata-notebook/requirements.txt
@@ -1,0 +1,10 @@
+matplotlib
+seaborn
+scikit-learn
+missingno
+streamlit
+dbt-core
+dbt-duckdb
+prefect
+ydata-profiling>=4.16.1
+ipykernel


### PR DESCRIPTION
Add a new bidata notebook with requirements for data analytics and engineering.

This image creates a new environment, installs a Python 3.12 in it and then replaces the standard kernel with this environment, effectively separating base packages like Jupyter Notebook, e2xgrader etc from the course packages.